### PR TITLE
Fix for issue "Reloading duplicates the onTaps"

### DIFF
--- a/lib/drawer_manager.dart
+++ b/lib/drawer_manager.dart
@@ -407,6 +407,13 @@ class DrawerTile extends ListTile {
 
         final dMProvider = Provider.of<DrawerManagerProvider>(context, listen: false);        
         if(onTap != null) {
+
+            final drawerSelectionCount = dMProvider.drawerSelections.length;
+            final drawerTileCount = dMProvider.onTapFunctions.length;
+            
+            if(drawerSelectionCount > 0 && drawerTileCount >= drawerSelectionCount) {
+                dMProvider.onTapFunctions.clear();
+            }
             dMProvider.onTapFunctions.add(onTap);
         } else {
             dMProvider.onTapFunctions.add(getDefaultCallback());


### PR DESCRIPTION
Issue Link: https://github.com/the-mac/drawer_manager/issues/1#issue-1177587391

This pull request allows for reloading the app without triggering the following assertion:
```bash
Failed assertion: line 210 pos 12: 'drawerTileCount <= drawerSelectionCount'
```
```dart

    var drawerSelectionCount = tileSelections.length;
    final drawerTileCount = dmProvider.onTapFunctions.length;
    
    final drawerTileCountErrorMessage = 'The DrawerTile count is more than the drawer selections. Check that your DrawerTiles ($drawerTileCount), and your selections ($drawerSelectionCount) match.';
    assert(drawerTileCount <= drawerSelectionCount, drawerTileCountErrorMessage);

```
